### PR TITLE
Extension registration updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         environmentVariablesYaml: |
           {}
         secretsYaml: |
-          BUILDVAR_PowerShellGalleryApiKey: ${{ secrets.PSGALLERY_APIKEY }}
+          ZF_BUILD_PS_REPOSITORY_APIKEY: ${{ secrets.PSGALLERY_APIKEY }}
         secretsEncryptionKey: ${{ secrets.SHARED_WORKFLOW_KEY }}
 
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-build-process@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,6 @@ on:
         required: true
         default: false
         type: boolean
-      psRepository:
-        description: The PowerShell repository used when publishing the module
-        required: true
-        default: github
-        type: string
 
 permissions:
   checks: write  # enable test result annotations

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -1,12 +1,10 @@
 # Extensions setup
 $zerofailedExtensions = @(
     @{
-        # Temporarily use pre-ZF build tooling until the required functionality has been migrated
-        Name = "Endjin.RecommendedPractices.Build"
-        Process = "tasks/build.process.ps1"
-        Version = "1.5.12"
+        Name = "ZeroFailed.Build.PowerShell"
+        GitRepository = "https://github.com/zerofailed/ZeroFailed.Build.PowerShell.git"
+        GitRef = "main"
     }
-    # TODO: Add support for obtaining extensions via Git?
 )
 
 # Load the tasks and process

--- a/module/functions/Register-ExtensionAndDependencies.Tests.ps1
+++ b/module/functions/Register-ExtensionAndDependencies.Tests.ps1
@@ -85,7 +85,7 @@ Describe 'Register-ExtensionAndDependencies' {
 
                 $result[1].Name | Should -Be "ZeroFailed.DevOps.Common"
                 $result[1].Version | Should -Be $null
-                $result[1].GitRef | Should -Be $null
+                $result[1].GitRef | Should -Be "main"
                 $result[1].Enabled | Should -Be $true
             }
         }
@@ -114,7 +114,7 @@ Describe 'Register-ExtensionAndDependencies' {
 
                 $result[2].Name | Should -Be "ZeroFailed.DevOps.Common"
                 $result[2].Version | Should -Be $null
-                $result[2].GitRef | Should -Be $null
+                $result[2].GitRef | Should -Be "main"
                 $result[2].Enabled | Should -Be $true
             }
         }

--- a/module/import-tasks.ps1
+++ b/module/import-tasks.ps1
@@ -22,9 +22,23 @@ $taskGroups | ForEach-Object {
 # scenarios (e.g. .NET Build, Python Build, Azure Deployment etc.), but a customised set
 # of extensions can be specified in 2 ways:
 #  1) Defining the '$zerofailedExtensions' variable early in the calling script (i.e. before calling 'ZeroFailed.tasks')
-#  2) Via the 'ZF_EXTENSIONS' environment variables, however note that the former method will take precedence over the environment variable
-if ($null -eq $zerofailedExtensions) {
-    [string[]]$zerofailedExtensions = $env:ZF_EXTENSIONS ? ($env:ZF_EXTENSIONS -split ";" | ForEach-Object { $_ }) : @()
+#  2) Via the 'ZF_EXTENSIONS' environment variable containing a JSON string with the same structure as #1. Note that this method will take precedence over #1.
+if ($env:ZF_EXTENSIONS) {
+    if ($zerofailedExtensions) {
+        Write-Host "Overriding extensions configuration with environment variable 'ZF_EXTENSIONS'" -f Green
+    }
+    else {
+        Write-Host "Loading extensions configuration from environment variable 'ZF_EXTENSIONS'" -f Green
+    }
+
+    try {
+        [hashtable[]]$zerofailedExtensions = $env:ZF_EXTENSIONS | ConvertFrom-Json -AsHashtable
+    }
+    catch {
+        Write-Warning "Failed to parse environment variable 'ZF_EXTENSIONS' as JSON: $($_.Exception.Message)"
+        Write-Verbose "ZF_EXTENSIONS: $env:ZF_EXTENSIONS"
+        [hashtable[]]$zerofailedExtensions = @()
+    }
 }
 
 # By default, extensions are loaded from the PowerShell Gallery, but this can be overridden

--- a/module/import-tasks.ps1
+++ b/module/import-tasks.ps1
@@ -6,21 +6,8 @@ param (
     [Parameter(Mandatory)]
     [string] $ZfPath
 )
-# Load core task definitions
-# TBC: What should constitute a core task?
-# NOTE: These are currently overridden when importing the original 'Endjin.RecommendedPractices.Build'
-#       module as an extension.
-$taskGroups = @()
-$taskGroups | ForEach-Object {
-    $taskFilename = "$_.tasks.ps1"
-    $taskFilePath = Resolve-Path ([IO.Path]::Combine($PSScriptRoot, "tasks", $taskFilename))
-    Write-Verbose "Importing core task: $taskFilename"
-    . $taskFilePath
-}
 
-# Functionality is provided by extensions, for convenience we can provide 1 or more common
-# scenarios (e.g. .NET Build, Python Build, Azure Deployment etc.), but a customised set
-# of extensions can be specified in 2 ways:
+# Functionality is provided by extensions that are specified in 2 ways:
 #  1) Defining the '$zerofailedExtensions' variable early in the calling script (i.e. before calling 'ZeroFailed.tasks')
 #  2) Via the 'ZF_EXTENSIONS' environment variable containing a JSON string with the same structure as #1. Note that this method will take precedence over #1.
 if ($env:ZF_EXTENSIONS) {


### PR DESCRIPTION
- Enable the environment variable approach for defining extensions to support the full extension specification syntax (i.e. it now needs to be a JSON string)
- Allow then environment variable extension config to override the script-based configuration
- Enable use of local or in-line process definitions and not just processes included in extensions
- Enable dependent extensions to override elements defined in their dependencies
- Update build to use the now available ZF PowerShell build extension