### PR TITLE
Fix registration issue when referencing only a single extension

### DIFF
--- a/module/import-tasks.ps1
+++ b/module/import-tasks.ps1
@@ -36,7 +36,7 @@ $zerofailedExtensionsRepository ??= !$env:ZF_EXTENSIONS_PS_REPO ? "PSGallery" : 
 # filling-out the addtional metadata required by subsequent steps to load them.
 if ($zerofailedExtensions.Count -gt 0) {
     Write-Host "*** Registering Extensions..." -f Green
-    $registeredExtensions = Register-Extensions -Extensions $zerofailedExtensions `
+    [array]$registeredExtensions = Register-Extensions -Extensions $zerofailedExtensions `
                                                 -DefaultPSRepository $zerofailedExtensionsRepository `
                                                 -ZfPath $ZfPath `
                                                 -Verbose:$VerbosePreference


### PR DESCRIPTION
Workaround PowerShell's habit of casting single item arrays into an object.