### PR TITLE
Allow extensions to specify multiple dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 PesterTestResults.xml
 .zf/extensions/
+_codeCoverage/
+_packages/

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -61,6 +61,7 @@ task . FullBuild
 # task PostPublish {}
 # task RunLast {}
 
+# Override & customise the default implementation to enable code coverage features
 task RunPesterTests `
     -If {!$SkipPesterTests -and $PesterTestsDir} `
     -After TestCore `
@@ -87,8 +88,7 @@ task RunPesterTests `
         -OutputPath $CoverageDir
     
     _GenerateCodeCoverageMarkdownReport `
-        -UseGitHubFlavour $IsGitHubActions `
-        -TargetFrameworkMoniker "PS7" `
+        -UseGitHubFlavour $IsGitHubActions
         -OutputPath $CoverageDir
 
     if ($results.FailedCount -gt 0) {

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -77,4 +77,8 @@ task RunPesterTests `
     if ($results.FailedCount -gt 0) {
         throw ("{0} out of {1} tests failed - check previous logging for more details" -f $results.FailedCount, $results.TotalCount)
     }
+
+    # debug where test results are in GHA
+    gci -Recurse -Path $here -Filter PesterTestResults.xml | out-string | write-host
+    gci -Recurse -Path $here -Filter pester-coverage.xml | out-string | write-host
 }

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -65,10 +65,12 @@ task RunPesterTests `
     $config.Run.PassThru = $true
     $config.Output.Verbosity = 'Normal'
     $config.TestResult.OutputFormat = $PesterOutputFormat
-    $config.TestResult.OutputPath = $PesterOutputFilePath
+    $config.TestResult.OutputPath = (Join-Path $here $PesterOutputFilePath)
     $config.CodeCoverage.Enabled = $true
     $config.CodeCoverage.OutputFormat = 'Cobertura'
     $config.CodeCoverage.OutputPath = (Join-Path $CoverageDir 'pester-coverage.xml')
+
+    $config | ConvertTo-Json -Depth 100 | Write-Host
 
     New-Item -ItemType Directory $CoverageDir -Force | Out-Null
 

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -64,6 +64,7 @@ task RunPesterTests `
     $config.Run.Path = $PesterTestsDir
     $config.Run.PassThru = $true
     $config.Output.Verbosity = 'Normal'
+    $config.TestResult.Enabled = $true
     $config.TestResult.OutputFormat = $PesterOutputFormat
     $config.TestResult.OutputPath = (Join-Path $here $PesterOutputFilePath)
     $config.CodeCoverage.Enabled = $true

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -88,7 +88,7 @@ task RunPesterTests `
         -OutputPath $CoverageDir
     
     _GenerateCodeCoverageMarkdownReport `
-        -UseGitHubFlavour $IsGitHubActions
+        -UseGitHubFlavour $IsGitHubActions `
         -OutputPath $CoverageDir
 
     if ($results.FailedCount -gt 0) {

--- a/build.ps1
+++ b/build.ps1
@@ -13,6 +13,9 @@ param (
     [string] $PackagesDir = "_packages",
 
     [Parameter()]
+    [string] $CoverageDir = "_codeCoverage",
+
+    [Parameter()]
     [ValidateSet("minimal","normal","detailed")]
     [string] $LogLevel = "minimal",
 

--- a/docs/adr/0001-managing-extension-dependency-metadata.md
+++ b/docs/adr/0001-managing-extension-dependency-metadata.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-* Status: proposed
+* Status: decided
 * Deciders: endjineers
 * Date: June 2025
 
@@ -25,22 +25,42 @@ Therefore a new approach is required for how extensions declare their dependenci
 
 ## Decision Outcome
 
-TBD
+Implement Option 2.
 
 ### Positive Consequences
 
-TBD
+* Fixes the original bug
+* Aligns with existing PowerShell tooling & conventions
+* Does not preclude use of additional metadata in the future
 
 ### Negative Consequences
 
-TBD
+* To avoid a breaking change the ZeroFailed module will need to support both approaches, at least in the short-term
+* Existing extensions will need to be updated to align with this new approach
 
 ## Pros and Cons of the Options
 
 ### Change the structure of the existing `dependencies.psd1` file
 
-This options involves changing the expected structure of the `dependencies.psd1` file to be as follows:
+This is the file's existing structure, that exhibits the issue outlined above:
+```
+@(
+    @{
+        Name = "Extension_A"
+    }
+    @{
+        Name = "Extension_B"
+        Version = "1.2.3"
+    }
+    @{
+        Name = "Extension_B"
+        GitRepository = "https://github.com/myOrg/Extension_C"
+        GitRef = "main"
+    }
+)
+```
 
+This option involves changing the expected structure of the `dependencies.psd1` file to be as follows:
 ```
 @{
     dependencies = @(
@@ -49,6 +69,12 @@ This options involves changing the expected structure of the `dependencies.psd1`
         }
         @{
             Name = "Extension_B"
+            Version = "1.2.3"
+        }
+        @{
+            Name = "Extension_B"
+            GitRepository = "https://github.com/myOrg/Extension_C"
+            GitRef = "main"
         }
     )
 }
@@ -83,6 +109,12 @@ This involves adding a 'ZeroFailed' key to the `PrivateData` part of the module 
                 }
                 @{
                     Name = "Extension_B"
+                    Version = "1.2.3"
+                }
+                @{
+                    Name = "Extension_B"
+                    GitRepository = "https://github.com/myOrg/Extension_C"
+                    GitRef = "main"
                 }
             )
         }

--- a/docs/adr/0001-managing-extension-dependency-metadata.md
+++ b/docs/adr/0001-managing-extension-dependency-metadata.md
@@ -1,0 +1,96 @@
+# Managing extension dependency metadata 
+
+## Status
+
+* Status: proposed
+* Deciders: endjineers
+* Date: June 2025
+
+## Context and Problem Statement
+
+The initial version ZeroFailed relied on extensions including the file `dependencies.psd1` with the details of any other extensions they depended on.  When being used on more complex scenarios a [bug](https://github.com/zerofailed/ZeroFailed/issues/5) was found when an extension tried to declare multiple dependencies.  Whilst the `Import-PowerShellDataFile` cmdlet will load a `.psd1` file containing an array of hashtables (as opposed to its intended format of a single hashtable), it will only return the first hashtable item.
+
+Therefore a new approach is required for how extensions declare their dependencies.
+
+## Decision Drivers
+
+* Must support declaring multiple dependencies
+* Backwards-compatibility considerations
+* Use of custom files vs. leveraging existing PowerShell module infrastructure
+
+## Considered Options
+
+* Option 1: Change the structure of the existing `dependencies.psd1` file
+* Option 2: Store dependency metadata as PowerShell module [PrivateData](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.psmoduleinfo.privatedata)
+
+## Decision Outcome
+
+TBD
+
+### Positive Consequences
+
+TBD
+
+### Negative Consequences
+
+TBD
+
+## Pros and Cons of the Options
+
+### Change the structure of the existing `dependencies.psd1` file
+
+This options involves changing the expected structure of the `dependencies.psd1` file to be as follows:
+
+```
+@{
+    dependencies = @(
+        @{
+            Name = "Extension_A"
+        }
+        @{
+            Name = "Extension_B"
+        }
+    )
+}
+```
+
+* Good, because it requires minimal changes to the core ZeroFailed module
+* Good, because backwards-compatibility can be retained without having to support 2 completely different approaches
+* Bad, since all extensions will ultimately need to be updated to adopt this new convention
+* Bad, arguably using a custom file creates clutter in the extensions
+
+### Store dependency metadata as PowerShell module PrivateData
+
+This involves adding a 'ZeroFailed' key to the `PrivateData` part of the module manifest, as illustrated below:
+```
+@{
+    # Script module or binary module file associated with this manifest.
+    RootModule = 'ZeroFailed.psm1'
+
+    ...
+
+    PrivateData = @{
+
+        PSData = @{
+            
+            ...
+
+        }
+        ZeroFailed = @{
+            Dependencies = @(
+                @{
+                    Name = "Extension_A"
+                }
+                @{
+                    Name = "Extension_B"
+                }
+            )
+        }
+    }
+}
+```
+
+* Good, arguably a more elegant solution to maintain the dependency details as part of the PowerShell module metadata
+* Good, it provides a more future-proof and generic facility to store ZeroFailed-related metadata
+* Bad, because backwards-compatibility can only be retained by supporting (at least temporarily) 2 different approaches for determining dependencies
+* Bad, since all extensions will ultimately need to be updated to adopt this new convention

--- a/module/functions/Get-ExtensionDependencies.Tests.ps1
+++ b/module/functions/Get-ExtensionDependencies.Tests.ps1
@@ -28,6 +28,8 @@ Describe 'Get-ExtensionDependencies' {
                 }
             }
         }
+        Mock Write-Warning {}
+        Mock Write-Host {}
     }
 
     Context 'No dependencies' {
@@ -42,7 +44,6 @@ Describe 'Get-ExtensionDependencies' {
                 Set-Content -Path $mockDependenciesPsd1FilePath -Value $extensionDependencies
 
                 Mock Import-PowerShellDataFile -ParameterFilter { $Path -ne $mockDependenciesPsd1FilePath } { $mockLegacyModuleManifest }
-                Mock Write-Warning {}
 
                 [array]$deps = Get-ExtensionDependencies $extensionConfig
             }
@@ -95,7 +96,6 @@ Describe 'Get-ExtensionDependencies' {
                 Set-Content -Path $mockDependenciesPsd1FilePath -Value $extensionDependencies
 
                 Mock Import-PowerShellDataFile -ParameterFilter { $Path -ne $mockDependenciesPsd1FilePath } { $mockLegacyModuleManifest }
-                Mock Write-Warning {}
 
                 [array]$deps = Get-ExtensionDependencies $extensionConfig
             }
@@ -171,7 +171,6 @@ Describe 'Get-ExtensionDependencies' {
                 Set-Content -Path $mockDependenciesPsd1FilePath -Value $extensionDependencies
                 
                 Mock Import-PowerShellDataFile -ParameterFilter { $Path -ne $mockDependenciesPsd1FilePath } { $mockLegacyModuleManifest }
-                Mock Write-Warning {}
                 [array]$deps = Get-ExtensionDependencies $extensionConfig
             }
             AfterAll {

--- a/module/functions/Get-ExtensionDependencies.Tests.ps1
+++ b/module/functions/Get-ExtensionDependencies.Tests.ps1
@@ -297,4 +297,30 @@ Describe 'Get-ExtensionDependencies' {
             } | Should -Throw "Failed to resolve extension metadata for dependency due to invalid configuration: Invalid extension configuration syntax*"
         }
     }
+    Context 'Unknown ZF configuration' {
+        BeforeAll {
+            $mockModuleManifest = @{
+                RootModule = "an-extension"
+                PrivateData = @{
+                    PSData = @{
+                        ExternalModuleDependencies = @()
+                    }
+                    ZeroFailed = @{
+                        RandomKey = 'foo'
+                    }
+                }
+            }
+            Mock Import-PowerShellDataFile { $mockModuleManifest }
+            Mock Write-Warning {}
+        }
+        AfterAll {}
+
+        It 'Should log a warning about unknown configuration settings' {
+            Get-ExtensionDependencies $extensionConfig
+
+            Should -Invoke Write-Warning -ParameterFilter {
+                $Message -eq "Unknown 'ZeroFailed' configuration keys were detected in the extension's module manifest: RandomKey"
+            }
+        }
+    }
 }

--- a/module/functions/Get-ExtensionDependencies.Tests.ps1
+++ b/module/functions/Get-ExtensionDependencies.Tests.ps1
@@ -270,4 +270,32 @@ Describe 'Get-ExtensionDependencies' {
             }
         }
     }
+
+    Context 'Invalid dependency configuration' {
+        BeforeAll {
+            $mockModuleManifest = @{
+                RootModule = "an-extension"
+                PrivateData = @{
+                    PSData = @{
+                        ExternalModuleDependencies = @()
+                    }
+                    ZeroFailed = @{
+                        ExtensionDependencies = @(
+                            @{
+                                InvalidKey = "InvalidValue"
+                            }
+                        )
+                    }
+                }
+            }
+            Mock Import-PowerShellDataFile { $mockModuleManifest }
+        }
+        AfterAll {}
+
+        It 'Should throw an exception with the correct message' {
+            {
+                Get-ExtensionDependencies $extensionConfig
+            } | Should -Throw "Failed to resolve extension metadata for dependency due to invalid configuration: Invalid extension configuration syntax*"
+        }
+    }
 }

--- a/module/functions/Get-ExtensionDependencies.Tests.ps1
+++ b/module/functions/Get-ExtensionDependencies.Tests.ps1
@@ -1,0 +1,73 @@
+# <copyright file="Get-ExtensionDependencies.Tests.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+BeforeAll {
+    # sut
+    . $PSCommandPath.Replace('.Tests.ps1','.ps1')
+
+    # in-module dependencies
+    . (Join-Path (Split-Path -Parent $PSCommandPath) 'Resolve-ExtensionMetadata.ps1')
+}
+
+Describe 'Get-ExtensionDependencies' {
+    # Setup TestDrive with sample extension
+    BeforeAll {
+        # Setup .zf folder
+        $extensionPath = Join-Path -Path TestDrive: -ChildPath 'fake-extension'
+        New-Item -Path $extensionPath -ItemType Directory -Force | Out-Null
+        $extensionConfig = @{
+            Name = "fake-extension"
+            Path = $extensionPath
+        }
+    }
+
+    Context 'Single dependency' {
+        BeforeAll {
+            $extensionDependencies = @'
+@{
+    Name = "an-extension"
+    Version = "1.0.0"
+}
+'@
+            Set-Content -Path (Join-Path $extensionPath 'dependencies.psd1') -Value $extensionDependencies
+            [array]$deps = Get-ExtensionDependencies $extensionConfig
+        }
+        AfterAll {}
+
+        It 'Should resolve the dependency' {
+            $deps.Count | Should -Be 1
+        }
+        It 'Should return the dependency metadata' {
+            $deps[0].Version | Should -Be '1.0.0'
+        }
+    }
+
+    Context 'Multiple dependencies' {
+        BeforeAll {
+            $extensionDependencies = @'
+@(
+    @{
+        Name = "an-extension"
+        Version = "1.0.0"
+    }
+    @{
+        Name = "another-extension"
+        Version = "2.0.0"
+    }
+)
+'@
+            Set-Content -Path (Join-Path $extensionPath 'dependencies.psd1') -Value $extensionDependencies
+            [array]$deps = Get-ExtensionDependencies $extensionConfig
+        }
+        AfterAll {}
+
+        It 'Should resolve all the dependencies' {
+            $deps.Count | Should -Be 2
+        }
+        It 'Should return the dependency metadata' {
+            $deps[0].Version | Should -Be '1.0.0'
+            $deps[1].Version | Should -Be '2.0.0'
+        }
+    }
+}

--- a/module/functions/Get-ExtensionDependencies.ps1
+++ b/module/functions/Get-ExtensionDependencies.ps1
@@ -130,9 +130,8 @@ function Get-ExtensionDependencies {
         catch {
             throw "Failed to resolve extension metadata for dependency due to invalid configuration: `n$($dependencyConfig | ConvertTo-Json -Depth 3)"
         }
-        # $resolvedDeps = $dependenciesConfig
     }
 
-    Write-Verbose "Resolved Dependencies: $($dependencyConfig | ConvertTo-Json -Depth 3)"
+    Write-Verbose "Resolved Dependencies: $($resolvedDeps | ConvertTo-Json -Depth 3)"
     return $resolvedDeps
 }

--- a/module/functions/Get-ExtensionDependencies.ps1
+++ b/module/functions/Get-ExtensionDependencies.ps1
@@ -4,10 +4,11 @@
 function Get-ExtensionDependencies {
     <#
         .SYNOPSIS
-        Retrieves the dependencies of a given extension by reading its `dependencies.psd1` file.
+        Retrieves the dependencies of a given extension by reading its module manifest.
 
         .DESCRIPTION
-        Retrieves the dependencies of a given extension by reading its `dependencies.psd1` file.
+        Retrieves the dependencies of a given extension by reading its module manifest and falling-back to
+        the legacy definition method in a `dependencies.psd1` file.
 
         .PARAMETER Extension
         The metadata object for the extension we are resolving dependencies for.
@@ -23,34 +24,52 @@ function Get-ExtensionDependencies {
         .EXAMPLE
         PS:> Get-ExtensionDependencies -Extension $extension
         @{
+            Name = "some-dependency"
+            Version = "1.0.0"
         }
         
         .NOTES
-        By convention an extension must declare its dependencies in a `dependencies.psd1` file located alongside
-        it's PowerShell module manifest file.  The contents of this file can be in one of two formats:
+        By convention an extension must declare its dependencies in its module manifest under the 'PrivateData'
+        key. The dependencies can be specified in one of two formats:
         
-        Short-hand syntax (single or multiple dependencies):
-        @(
-            'ExtensionA'
-        )
+        Short-hand syntax:
+            PrivateData = @{
+                ZeroFailed = @{
+                    ExtensionDependencies = @(
+                        'ExtensionA'
+                    )
+                }
+            }
         
-        Full syntax (single dependency):
-        @{
-            Name = 'ExtensionA'
-            Version = '1.0.0'
-        }
-
-        Full syntax (multiple dependencies):
-        @(
-            @{
-                Name = 'ExtensionA'
-                Version = '1.0.0'
+        Full syntax:
+            PrivateData = @{
+                ZeroFailed = @{
+                    ExtensionDependencies = @(
+                        @{
+                            Name = 'ExtensionA'
+                            Version = '1.0.0'
+                        }
+                        @{
+                            Name = 'MyExtension'
+                            GitRepository = 'https://github.com/myorg/myextension
+                            GitRef = 'main'
+                        }
+                    )
+                }
             }
-            @{
-                Name = 'ExtensionB'
-                Version = '2.0.0'
+        
+        Mixed syntax:
+            PrivateData = @{
+                ZeroFailed = @{
+                    ExtensionDependencies = @(
+                        'ExtensionA'
+                        @{
+                            Name = 'ExtensionB'
+                            Version = '2.0.0'
+                        }
+                    )
+                }
             }
-        )
     #>
 
     [CmdletBinding()]
@@ -59,24 +78,61 @@ function Get-ExtensionDependencies {
         [hashtable] $Extension
     )
 
-    $deps = @()
-    $depConfigPath = Join-Path -Path $Extension.Path -ChildPath 'dependencies.psd1'
-    if ((Test-Path $depConfigPath)) {
-        $dependencies = Import-PowerShellDataFile -Path $depConfigPath
-        
-        if ($dependencies.Keys.Count -gt 0) {
-            $dependencies | ForEach-Object {
-                try {
-                    # Use existing logic to resolve the supported syntaxes into the canonical form
-                    $deps += Resolve-ExtensionMetadata -Value $_
-                }
-                catch {
-                    throw "Failed to resolve extension metadata for dependency due to invalid configuration: `n$($_ | ConvertTo-Json)"
-                }
+    # Constants
+    $ZF_PRIVATEDATA_KEY_NAME = "ZeroFailed"
+    $ZF_EXTENSION_DEPENDENCIES_KEY_NAME = "ExtensionDependencies"
+
+    $resolvedDeps = @()
+    $dependenciesConfig = $null
+
+    # We currently support 2 mechanisms for extensions to declare their dependencies:
+    #  1. via a 'dependencies.psd1' (considered legacy due to a structural bug)
+    #  2. via configuration stored in the module manifest under the 'PrivateData' key
+    #
+    # Option 2 is preferred with Option 1 retained as a fallback for backwards-compatibility.
+
+    $extensionModuleManifestPath = Join-Path -Path $Extension.Path -ChildPath "$($Extension.Name).psd1"
+    $extensionModuleManifest = Import-PowerShellDataFile -Path $extensionModuleManifestPath
+    if ($extensionModuleManifest.ContainsKey("PrivateData") -and `
+            $extensionModuleManifest.PrivateData.ContainsKey($ZF_PRIVATEDATA_KEY_NAME) -and `
+            $extensionModuleManifest.PrivateData.$ZF_PRIVATEDATA_KEY_NAME.ContainsKey($ZF_EXTENSION_DEPENDENCIES_KEY_NAME)
+    ) {
+        Write-Verbose "Reading dependencies from module manifest"
+        $dependenciesConfig = $extensionModuleManifest.PrivateData.$ZF_PRIVATEDATA_KEY_NAME.$ZF_EXTENSION_DEPENDENCIES_KEY_NAME
+    }
+    else {
+        # Fallback to legacy mechanism as backwards-compatibility measure
+        $legacyDepConfigPath = Join-Path -Path $Extension.Path -ChildPath 'dependencies.psd1'
+        if ((Test-Path $legacyDepConfigPath)) {
+            Write-Warning "Reading dependencies from 'dependencies.psd1', which is now deprecated. The extension developer should move them to the module manifest under the 'PrivateData.$ZF_PRIVATEDATA_KEY_NAME.$ZF_EXTENSION_DEPENDENCIES_KEY_NAME' key."
+
+            # Log a warning if an array syntax has been used (i.e. potentially multiple dependencies have been specified)
+            # Whilst 'Import-PowerShellDataFile' will process such a file without error, it will
+            # only return the first item in the array.
+            if ((Get-Content $legacyDepConfigPath -Raw).TrimStart().StartsWith("@(")) {
+                Write-Warning "Possible multiple dependencies in 'dependencies.psd1'; this is not supported, only the first one will be available. Please migrate to the above method."
             }
-            $deps = $dependencies
+
+            $dependenciesConfig = Import-PowerShellDataFile -Path $legacyDepConfigPath
+            if ($dependenciesConfig.Keys.Count -eq 0) {
+                # Ensure an empty .psd1 file is treated as no dependencies
+                $dependenciesConfig = $null
+            }
         }
     }
 
-    return $deps
+    # Detect if no dependencies
+    foreach ($dependencyConfig in [array]$dependenciesConfig) {
+        try {
+            # Use existing logic to resolve the supported syntaxes into the canonical form
+            $resolvedDeps += Resolve-ExtensionMetadata -Value $dependencyConfig
+        }
+        catch {
+            throw "Failed to resolve extension metadata for dependency due to invalid configuration: `n$($dependencyConfig | ConvertTo-Json -Depth 3)"
+        }
+        # $resolvedDeps = $dependenciesConfig
+    }
+
+    Write-Verbose "Resolved Dependencies: $($dependencyConfig | ConvertTo-Json -Depth 3)"
+    return $resolvedDeps
 }

--- a/module/functions/Get-ExtensionDependencies.ps1
+++ b/module/functions/Get-ExtensionDependencies.ps1
@@ -128,7 +128,7 @@ function Get-ExtensionDependencies {
             $resolvedDeps += Resolve-ExtensionMetadata -Value $dependencyConfig
         }
         catch {
-            throw "Failed to resolve extension metadata for dependency due to invalid configuration: `n$($dependencyConfig | ConvertTo-Json -Depth 3)"
+            throw "Failed to resolve extension metadata for dependency due to invalid configuration: $($_.Exception.Message)`ndependencyConfig: $($dependencyConfig | ConvertTo-Json -Depth 3)"
         }
     }
 

--- a/module/functions/Get-ExtensionDependencies.ps1
+++ b/module/functions/Get-ExtensionDependencies.ps1
@@ -94,11 +94,17 @@ function Get-ExtensionDependencies {
     $extensionModuleManifestPath = Join-Path -Path $Extension.Path -ChildPath "$($Extension.Name).psd1"
     $extensionModuleManifest = Import-PowerShellDataFile -Path $extensionModuleManifestPath
     if ($extensionModuleManifest.ContainsKey("PrivateData") -and `
-            $extensionModuleManifest.PrivateData.ContainsKey($ZF_PRIVATEDATA_KEY_NAME) -and `
-            $extensionModuleManifest.PrivateData.$ZF_PRIVATEDATA_KEY_NAME.ContainsKey($ZF_EXTENSION_DEPENDENCIES_KEY_NAME)
+            $extensionModuleManifest.PrivateData.ContainsKey($ZF_PRIVATEDATA_KEY_NAME)
     ) {
-        Write-Verbose "Reading dependencies from module manifest"
-        $dependenciesConfig = $extensionModuleManifest.PrivateData.$ZF_PRIVATEDATA_KEY_NAME.$ZF_EXTENSION_DEPENDENCIES_KEY_NAME
+        if ($extensionModuleManifest.PrivateData.$ZF_PRIVATEDATA_KEY_NAME.ContainsKey($ZF_EXTENSION_DEPENDENCIES_KEY_NAME)) {
+            Write-Verbose "Reading dependencies from module manifest"
+            $dependenciesConfig = $extensionModuleManifest.PrivateData.$ZF_PRIVATEDATA_KEY_NAME.$ZF_EXTENSION_DEPENDENCIES_KEY_NAME
+        }
+        else {
+            if ($extensionModuleManifest.PrivateData.$ZF_PRIVATEDATA_KEY_NAME.Keys.Count -gt 0) {
+                Write-Warning "Unknown '$ZF_PRIVATEDATA_KEY_NAME' configuration keys were detected in the extension's module manifest: $($extensionModuleManifest.PrivateData.$ZF_PRIVATEDATA_KEY_NAME.Keys)"
+            }
+        }
     }
     else {
         # Fallback to legacy mechanism as backwards-compatibility measure

--- a/module/functions/Get-ExtensionFromGitRepository.Tests.ps1
+++ b/module/functions/Get-ExtensionFromGitRepository.Tests.ps1
@@ -17,6 +17,7 @@ Describe 'Get-ExtensionFromGitRepository' {
         # Setup .zf folder
         $targetPath = Join-Path -Path TestDrive: -ChildPath '.zf' 'extensions'
         New-Item -Path $targetPath -ItemType Directory -Force | Out-Null
+        Mock Write-Host {}
     }
 
     Context 'Installing extension from a simple branch reference' {

--- a/module/functions/Get-ExtensionFromPowerShellRepository.Tests.ps1
+++ b/module/functions/Get-ExtensionFromPowerShellRepository.Tests.ps1
@@ -16,6 +16,8 @@ Describe 'Get-ExtensionFromPowerShellRepository' {
         # Setup .zf folder
         $targetPath = Join-Path -Path TestDrive: -ChildPath '.zf' 'extensions'
         New-Item -Path $targetPath -ItemType Directory -Force | Out-Null
+        Mock Write-Host {}
+        Mock Write-Warning {}
     }
 
     Context 'When installing an extension without version constraint' {

--- a/module/functions/Register-ExtensionAndDependencies.Tests.ps1
+++ b/module/functions/Register-ExtensionAndDependencies.Tests.ps1
@@ -8,12 +8,14 @@ BeforeAll {
 
     # in-module dependencies
     . (Join-Path (Split-Path -Parent $PSCommandPath) 'Get-ExtensionFromGitRepository.ps1')
+    . (Join-Path (Split-Path -Parent $PSCommandPath) 'Get-ExtensionFromPowerShellRepository.ps1')
     . (Join-Path (Split-Path -Parent $PSCommandPath) 'Get-InstalledExtensionDetails.ps1')
     . (Join-Path (Split-Path -Parent $PSCommandPath) 'Copy-FolderFromGitRepo.ps1')
     . (Join-Path (Split-Path -Parent $PSCommandPath) 'Get-ExtensionDependencies.ps1')
-
-    # make available for mocking
+    . (Join-Path (Split-Path -Parent $PSCommandPath) '_resolveModuleNameFromPath.ps1')
+    . (Join-Path (Split-Path -Parent $PSCommandPath) 'Resolve-ExtensionMetadata.ps1')
     . (Join-Path (Split-Path -Parent $PSCommandPath) 'Get-ExtensionAvailableTasks.ps1')
+    . (Join-Path (Split-Path -Parent $PSCommandPath) 'Get-TasksFileListFromExtension.ps1')
 }
 
 Describe 'Register-ExtensionAndDependencies' {
@@ -22,19 +24,92 @@ Describe 'Register-ExtensionAndDependencies' {
         $targetPath = Join-Path -Path TestDrive: -ChildPath '.zf' 'extensions'
         New-Item -Path $targetPath -ItemType Directory -Force | Out-Null
 
-        Mock Write-Host {}  # suppress logging
-        Mock Get-ExtensionAvailableTasks {
-            param ($ExtensionPath)
-            return @("MockTask1", "MockTask2")
-        }
+        # Define default PSRepository for PowerShell module-based extensions
+        $DefaultPSRepository = 'PSGallery'
+
+        Mock Write-Host {}
+        Mock Write-Warning {}
+        # Mock Get-ExtensionAvailableTasks {
+        #     param ($ExtensionPath)
+        #     return @("MockTask1", "MockTask2")
+        # }
     }
 
     Context 'Git-Based Extensions' {
+        BeforeAll {
+            Mock Get-ExtensionFromGitRepository {
+                param ($Name, $RepositoryUri, $TargetPath, $GitRef, $RepositoryFolderPath)
+                # Return only the additional properties that Register-ExtensionAndDependencies expects to add
+                return @{
+                    Path = Join-Path $TargetPath $Name $GitRef
+                    Enabled = $true # Ensure Enabled is returned
+                }
+            }
+            Mock Import-PowerShellDataFile {
+                param($Path)
+                switch ($Path) {
+                    { $PSItem.EndsWith('ZeroFailed.DevOps.Common.psd1') } {
+                        @{
+                            RootModule = 'ZeroFailed.DevOps.Common'
+                            PrivateData = @{
+                                PSData = @{
+                                    ExternalModuleDependencies = @()
+                                }
+                                ZeroFailed = @{
+                                    ExtensionDependencies = @()
+                                }
+                            }
+                        }
+                    }
+                    { $PSItem.EndsWith('ZeroFailed.Build.Common.psd1') } {
+                        @{
+                            RootModule = 'ZeroFailed.Build.Common'
+                            PrivateData = @{
+                                PSData = @{
+                                    ExternalModuleDependencies = @()
+                                }
+                                ZeroFailed = @{
+                                    ExtensionDependencies = @(
+                                        @{
+                                            Name = 'ZeroFailed.DevOps.Common'
+                                            GitRepository = 'https://github.com/zerofailed/ZeroFailed.DevOps.Common'
+                                            GitRef = 'main'
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    { $PSItem.EndsWith('ZeroFailed.Build.DotNet.psd1') } {
+                        @{
+                            RootModule = 'ZeroFailed.Build.DotNet'
+                            PrivateData = @{
+                                PSData = @{
+                                    ExternalModuleDependencies = @()
+                                }
+                                ZeroFailed = @{
+                                    ExtensionDependencies = @(
+                                        @{
+                                            Name = 'ZeroFailed.Build.Common'
+                                            GitRepository = 'https://github.com/zerofailed/ZeroFailed.Build.Common'
+                                            GitRef = 'main'
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    default {
+                        throw "Unhandled mock module manifest for '$PSItem'"
+                    }
+                }
+            }
+        }
         
         Context 'When processing a single extension with no dependencies (no version constraint)' {
             It 'Processes the extension and returns the correct metadata' {
                 $extensionConfig = @{
-                    Name = "ZeroFailed.DevOps.Common"                
+                    Name = "ZeroFailed.DevOps.Common"
                     GitRepository = "https://github.com/zerofailed/ZeroFailed.DevOps.Common"
                 }
     
@@ -51,7 +126,7 @@ Describe 'Register-ExtensionAndDependencies' {
         Context 'When processing a single extension with no dependencies  (with version constraint)' {
             It 'Processes the extension and returns the correct metadata' {
                 $extensionConfig = @{
-                    Name = "ZeroFailed.DevOps.Common"                
+                    Name = "ZeroFailed.DevOps.Common"
                     GitRepository = "https://github.com/zerofailed/ZeroFailed.DevOps.Common"
                     GitRef = "refs/heads/main"
                 }
@@ -69,7 +144,7 @@ Describe 'Register-ExtensionAndDependencies' {
         Context 'When processing a single extension with 1 dependency (version constraint)' {
             It 'Processes the extension and returns the correct metadata' {
                 $extensionConfig = @{
-                    Name = "ZeroFailed.Build.Common"                
+                    Name = "ZeroFailed.Build.Common"
                     GitRepository = "https://github.com/zerofailed/ZeroFailed.Build.Common"
                     GitRef = "refs/heads/main"
                 }
@@ -93,7 +168,7 @@ Describe 'Register-ExtensionAndDependencies' {
         Context 'When processing a single extension with multiple dependencies (version constraint)' {
             It 'Processes the extension and returns the correct metadata' {
                 $extensionConfig = @{
-                    Name = "ZeroFailed.Build.DotNet"                
+                    Name = "ZeroFailed.Build.DotNet"
                     GitRepository = "https://github.com/zerofailed/ZeroFailed.Build.DotNet"
                     GitRef = "refs/heads/main"
                 }
@@ -109,13 +184,466 @@ Describe 'Register-ExtensionAndDependencies' {
 
                 $result[1].Name | Should -Be "ZeroFailed.Build.Common"
                 $result[1].Version | Should -Be $null
-                $result[1].GitRef | Should -Be $null
+                $result[1].GitRef | Should -Be "main"
                 $result[1].Enabled | Should -Be $true
 
                 $result[2].Name | Should -Be "ZeroFailed.DevOps.Common"
                 $result[2].Version | Should -Be $null
                 $result[2].GitRef | Should -Be "main"
                 $result[2].Enabled | Should -Be $true
+            }
+        }
+    }
+
+    Context 'PowerShell Module-Based Extensions' {
+        BeforeAll {
+            $mockModuleName = 'MyZfExtension'
+            $mockModuleVersion = '1.2.3'
+            $mockPsRepo = "MyPSRepo"
+            Mock Get-ExtensionDependencies {
+                return @()
+            }
+            Mock Find-PSResource { 
+                # Minimum properties required to fake a PS module being available on a repository
+                return New-MockObject -Type 'Microsoft.PowerShell.PSResourceGet.UtilClasses.PSResourceInfo' -Properties @{ Name = $mockModuleName; Repository = $mockPsRepo }
+            }
+            Mock Save-PSResource {
+                # Create the minimum filesystem structure needed to fake the installation of a ZF extension
+                New-Item -ItemType Directory -Path (Join-Path $Path $InputObject.Name $mockModuleVersion) -Force | Out-Null
+            }
+            Mock Import-PowerShellDataFile {
+                return @{
+                    RootModule = $mockModuleName
+                    PrivateData = @{
+                        PSData = @{
+                            ExternalModuleDependencies = @()
+                        }
+                        ZeroFailed = @{
+                            ExtensionDependencies = @()
+                        }
+                    }
+                }
+            }
+        }
+
+        Context 'When processing a single PowerShell module extension (no PSRepository specified)' {
+            It 'Processes the extension and returns the correct metadata' {
+                $extensionConfig = @{
+                    Name = $mockModuleName
+                }
+
+                [array]$result = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath
+
+                $result.Count | Should -Be 1
+                $result[0].Name | Should -Be $mockModuleName
+                $result[0].Version | Should -Be $mockModuleVersion
+                $result[0].Enabled | Should -Be $true
+                Should -Invoke Find-PSResource -Exactly 1
+                Should -Invoke Save-PSResource -Exactly 1
+            }
+        }
+
+        Context 'When processing a single PowerShell module extension (with PSRepository specified)' {
+            It 'Processes the extension and returns the correct metadata' {
+                $extensionConfig = @{
+                    Name = $mockModuleName
+                    PSRepository = $mockPsRepo
+                }
+
+                [array]$result = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath
+
+                $result.Count | Should -Be 1
+                $result[0].Name | Should -Be $mockModuleName
+                $result[0].Version | Should -Be $mockModuleVersion
+                $result[0].PSRepository | Should -Be $mockPsRepo
+                $result[0].Enabled | Should -Be $true
+                Should -Invoke Find-PSResource -Exactly 1
+                Should -Invoke Save-PSResource -Exactly 1
+            }
+        }
+    }
+
+    Context 'Local File-System-Based Extensions' {
+        BeforeAll {
+            Mock Write-Host {} -ParameterFilter { $Object.StartsWith("USING PATH:")}
+            $mockExtensionName = 'MyLocalZfExtension'
+            $mockExtensionPath = Join-Path -Path TestDrive: -ChildPath $mockExtensionName
+            New-Item -Path $mockExtensionPath -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $mockExtensionPath "$mockExtensionName.psd1") -Value @'
+@{
+    RootModule = 'ZeroFailed.psm1'
+    ModuleVersion = '0.0.1'
+    PrivateData = @{
+        ZFData = @{
+            Dependencies = @()
+        }
+    }
+}
+'@
+        }
+
+        Context 'When processing a single local file-system extension with a valid path' {
+            It 'Processes the extension and returns the correct metadata' {
+                $extensionConfig = @{
+                    Name = $mockExtensionName
+                    Path = $mockExtensionPath
+                }
+
+                [array]$result = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath
+
+                $result.Count | Should -Be 1
+                $result[0].Name | Should -Be $mockExtensionName
+                $result[0].Path | Should -Be $mockExtensionPath
+                $result[0].Enabled | Should -Be $true
+                Should -Invoke Write-Host -Exactly 1
+            }
+        }
+    }
+
+    # Context 'Disabled Extension Scenarios' {
+    #     BeforeEach {
+    #         # Reset mocks for each test in this context
+    #         Mock Test-Path {
+    #             param ($Path)
+    #             return $false # Default to false, override for specific tests
+    #         }
+    #         Mock Write-Warning {} # Capture Write-Warning output
+    #         Mock Get-ExtensionDependencies {
+    #             param ($Extension)
+    #             return @()
+    #         }
+    #         Mock Get-ExtensionAvailableTasks {
+    #             param ($ExtensionPath)
+    #             return @()
+    #         }
+    #         Mock Register-ExtensionAndDependencies {
+    #             param ($ExtensionConfig, $TargetPath)
+    #             # Prevent recursive calls from actually executing during these tests
+    #             return @($ExtensionConfig)
+    #         } -ParameterFilter { $ExtensionConfig.Name -ne "TestDisabledExtension" -and $ExtensionConfig.Name -ne "ExplicitlyDisabledExtension" }
+    #     }
+
+    #     Context 'Local extension path does not exist' {
+    #         It 'Should disable the extension and write a warning' {
+    #             Mock Resolve-ExtensionMetadata {
+    #                 param ($Value)
+    #                 $mockExtension = $Value.Clone()
+    #                 $mockExtension.Enabled = $true # Assume it's enabled initially
+    #                 return $mockExtension
+    #             }
+
+    #             $invalidPath = "$targetPath/non-existent-local-extension"
+    #             $extensionConfig = @{
+    #                 Name = "TestDisabledExtension"
+    #                 Path = $invalidPath
+    #             }
+
+    #             [array]$result = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath
+
+    #             $result.Count | Should -Be 1
+    #             $result[0].Name | Should -Be "TestDisabledExtension"
+    #             $result[0].Enabled | Should -Be $false
+    #             Should -Invoke Write-Warning -Exactly 1 -ParameterFilter {
+    #                 $_.ToString() -like "Extension 'TestDisabledExtension' not found at $invalidPath - it has been disabled.*"
+    #             }
+    #             Should -Not -Invoke Get-ExtensionDependencies
+    #             Should -Not -Invoke Get-ExtensionAvailableTasks
+    #             Should -Not -Invoke Register-ExtensionAndDependencies -ParameterFilter { $ExtensionConfig.Name -ne "TestDisabledExtension" }
+    #         }
+    #     }
+
+    #     Context 'Extension explicitly disabled via configuration' {
+    #         It 'Should not process dependencies or tasks' {
+    #             Mock Resolve-ExtensionMetadata {
+    #                 param ($Value)
+    #                 $mockExtension = $Value.Clone()
+    #                 $mockExtension.Enabled = $false
+    #                 return $mockExtension
+    #             }
+
+    #             $extensionConfig = @{
+    #                 Name = "ExplicitlyDisabledExtension"
+    #                 Path = "$targetPath/some-path" # Path doesn't matter as Resolve-ExtensionMetadata is mocked
+    #                 Enabled = $false # This will be overridden by mock
+    #             }
+
+    #             [array]$result = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath
+
+    #             $result.Count | Should -Be 1
+    #             $result[0].Name | Should -Be "ExplicitlyDisabledExtension"
+    #             $result[0].Enabled | Should -Be $false
+    #             Should -Not -Invoke Get-ExtensionDependencies
+    #             Should -Not -Invoke Get-ExtensionAvailableTasks
+    #             Should -Not -Invoke Register-ExtensionAndDependencies -ParameterFilter { $ExtensionConfig.Name -ne "ExplicitlyDisabledExtension" }
+    #         }
+    #     }
+    # }
+
+    # Context 'Dependency Resolution Edge Cases' {
+    #     BeforeEach {
+    #         # Reset mocks for each test in this context
+    #         Mock Resolve-ExtensionMetadata {
+    #             param ($Value)
+    #             if ($Value -is [string]) {
+    #                 return @{ Name = $Value; Path = $Value; Enabled = $true }
+    #             }
+    #             return $Value
+    #         }
+    #         Mock Get-ExtensionDependencies {
+    #             param ($Extension)
+    #             return @() # Default to no dependencies, override for specific tests
+    #         }
+    #         Mock Get-ExtensionFromGitRepository {
+    #             param ($Name, $RepositoryUri, $TargetPath)
+    #             return @{ Path = Join-Path $TargetPath $Name }
+    #         }
+    #         Mock Get-ExtensionFromPowerShellRepository {
+    #             param ($Name, $PSRepository, $TargetPath)
+    #             return @{ Path = Join-Path $TargetPath $Name }
+    #         }
+    #         Mock Test-Path {
+    #             param ($Path)
+    #             return $true # Default to path exists
+    #         }
+    #         Mock Write-Warning {}
+    #         Mock Write-Host {}
+    #         Mock Register-ExtensionAndDependencies {
+    #             param ($ExtensionConfig, $TargetPath)
+    #             # Allow recursive calls to be tracked, but return a simple processed config
+    #             return @($ExtensionConfig)
+    #         } -ParameterFilter { $ExtensionConfig.Name -ne "CircularDependencyB" -and $ExtensionConfig.Name -ne "NonExistentDependency" -and $ExtensionConfig.Name -ne "CommonDependency" }
+    #     }
+
+    #     Context 'Extension with no dependencies' {
+    #         It 'Should only process the main extension' {
+    #             $extensionConfig = @{
+    #                 Name = "ExtensionNoDeps"
+    #                 GitRepository = "https://github.com/test/nodeps"
+    #             }
+
+    #             [array]$result = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath
+
+    #             $result.Count | Should -Be 1
+    #             $result[0].Name | Should -Be "ExtensionNoDeps"
+    #             Should -Invoke Get-ExtensionDependencies -Exactly 1 -ParameterFilter { $Extension.Name -eq "ExtensionNoDeps" }
+    #             Should -Not -Invoke Register-ExtensionAndDependencies -ParameterFilter { $ExtensionConfig.Name -ne "ExtensionNoDeps" }
+    #         }
+    #     }
+
+    #     # Context 'Circular Dependencies (A -> B -> A)' {
+    #     #     It 'Should process each unique extension only once' {
+    #     #         Mock Get-ExtensionDependencies {
+    #     #             param ($Extension)
+    #     #             if ($Extension.Name -eq "CircularDependencyA") {
+    #     #                 return @(@{ Name = "CircularDependencyB"; GitRepository = "https://github.com/test/B" })
+    #     #             }
+    #     #             if ($Extension.Name -eq "CircularDependencyB") {
+    #     #                 return @(@{ Name = "CircularDependencyA"; GitRepository = "https://github.com/test/A" })
+    #     #             }
+    #     #             return @()
+    #     #         }
+
+    #     #         # Mock Register-ExtensionAndDependencies to prevent infinite recursion and track calls
+    #     #         $processedCalls = [System.Collections.Generic.List[string]]::new()
+    #     #         Mock Register-ExtensionAndDependencies {
+    #     #             param ($ExtensionConfig, $TargetPath)
+    #     #             if (-not ($processedCalls.Contains($ExtensionConfig.Name))) {
+    #     #                 $processedCalls.Add($ExtensionConfig.Name)
+    #     #                 # Call original function for the first time, then return mock for subsequent calls
+    #     #                 if ($ExtensionConfig.Name -eq "CircularDependencyA") {
+    #     #                     return (Invoke-MockOriginal -ExtensionConfig $ExtensionConfig -TargetPath $TargetPath)
+    #     #                 }
+    #     #             }
+    #     #             return @($ExtensionConfig) # Return a simple mock for subsequent calls
+    #     #         } -MockWith { Invoke-MockOriginal } -ParameterFilter { $ExtensionConfig.Name -eq "CircularDependencyA" }
+
+    #     #         $extensionConfig = @{
+    #     #             Name = "CircularDependencyA"
+    #     #             GitRepository = "https://github.com/test/A"
+    #     #         }
+
+    #     #         [array]$result = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath
+
+    #     #         $result.Count | Should -Be 2 # A and B should be in the final list
+    #     #         $result.Name | Should -Contain "CircularDependencyA"
+    #     #         $result.Name | Should -Contain "CircularDependencyB"
+
+    #     #         # Verify that Register-ExtensionAndDependencies was called for each unique dependency once
+    #     #         $processedCalls.Count | Should -Be 2
+    #     #         $processedCalls | Should -Contain "CircularDependencyA"
+    #     #         $processedCalls | Should -Contain "CircularDependencyB"
+    #     #     }
+    #     # }
+
+    #     Context 'Non-existent Dependency' {
+    #         It 'Should mark the non-existent dependency as disabled and warn' {
+    #             Mock Get-ExtensionDependencies {
+    #                 param ($Extension)
+    #                 if ($Extension.Name -eq "MainExtension") {
+    #                     return @(@{ Name = "NonExistentDependency"; Path = "$targetPath/non-existent-dep" })
+    #                 }
+    #                 return @()
+    #             }
+    #             Mock Test-Path {
+    #                 param ($Path)
+    #                 return $Path -ne "$targetPath/non-existent-dep"
+    #             }
+    #             Mock Resolve-ExtensionMetadata {
+    #                 param ($Value)
+    #                 if ($Value.Name -eq "NonExistentDependency") {
+    #                     return @{ Name = "NonExistentDependency"; Path = "$targetPath/non-existent-dep"; Enabled = $true } # Assume initially enabled
+    #                 }
+    #                 return $Value
+    #             }
+
+    #             $extensionConfig = @{
+    #                 Name = "MainExtension"
+    #                 GitRepository = "https://github.com/test/main"
+    #             }
+
+    #             [array]$result = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath
+
+    #             $result.Count | Should -Be 2
+    #             $result.Name | Should -Contain "MainExtension"
+    #             $result.Name | Should -Contain "NonExistentDependency"
+    #             ($result | Where-Object Name -eq "NonExistentDependency").Enabled | Should -Be $false
+
+    #             Should -Invoke Write-Warning -Exactly 1 -ParameterFilter {
+    #                 $_.ToString() -like "Extension 'NonExistentDependency' not found at $targetPath/non-existent-dep - it has been disabled.*"
+    #             }
+    #         }
+    #     }
+
+    #     Context 'Duplicate Dependencies (A -> B, C -> B)' {
+    #         It 'Should process the duplicate dependency only once' {
+    #             Mock Get-ExtensionDependencies {
+    #                 param ($Extension)
+    #                 if ($Extension.Name -eq "ExtensionA") {
+    #                     return @(@{ Name = "CommonDependency"; GitRepository = "https://github.com/test/common" })
+    #                 }
+    #                 if ($Extension.Name -eq "ExtensionC") {
+    #                     return @(@{ Name = "CommonDependency"; GitRepository = "https://github.com/test/common" })
+    #                 }
+    #                 return @()
+    #             }
+
+    #             # Mock Register-ExtensionAndDependencies to track calls
+    #             $registerCalls = [System.Collections.Generic.List[string]]::new()
+    #             Mock Register-ExtensionAndDependencies {
+    #                 param ($ExtensionConfig, $TargetPath)
+    #                 $registerCalls.Add($ExtensionConfig.Name)
+    #                 return (Invoke-MockOriginal -ExtensionConfig $ExtensionConfig -TargetPath $TargetPath)
+    #             } -ParameterFilter { $ExtensionConfig.Name -ne "ExtensionA" -and $ExtensionConfig.Name -ne "ExtensionC" }
+
+    #             $extensionConfigA = @{
+    #                 Name = "ExtensionA"
+    #                 GitRepository = "https://github.com/test/A"
+    #             }
+    #             $extensionConfigC = @{
+    #                 Name = "ExtensionC"
+    #                 GitRepository = "https://github.com/test/C"
+    #             }
+
+    #             [array]$resultA = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfigA -TargetPath $targetPath
+    #             [array]$resultC = Register-ExtensionAndDependencies -ExtensionConfig $extensionConfigC -TargetPath $targetPath
+
+    #             # Combine results and ensure unique entries
+    #             $combinedResult = ($resultA + $resultC | Select-Object -Unique Name)
+
+    #             $combinedResult.Count | Should -Be 3
+    #             $combinedResult.Name | Should -Contain "ExtensionA"
+    #             $combinedResult.Name | Should -Contain "ExtensionC"
+    #             $combinedResult.Name | Should -Contain "CommonDependency"
+
+    #             # Verify that CommonDependency was processed only once by Register-ExtensionAndDependencies
+    #             ($registerCalls | Where-Object { $_ -eq "CommonDependency" }).Count | Should -Be 1
+    #         }
+    #     }
+    # }
+
+    # Context 'Error Handling of Internal Calls' {
+    #     BeforeEach {
+    #         # Reset mocks for each test in this context
+    #         Mock Resolve-ExtensionMetadata {
+    #             param ($Value)
+    #             if ($Value -is [string]) {
+    #                 return @{ Name = $Value; Path = $Value; Enabled = $true }
+    #             }
+    #             return $Value
+    #         }
+    #         Mock Get-ExtensionFromGitRepository {
+    #             param ($Name, $RepositoryUri, $TargetPath)
+    #             return @{ Path = Join-Path $TargetPath $Name }
+    #         }
+    #         Mock Get-ExtensionFromPowerShellRepository {
+    #             param ($Name, $PSRepository, $TargetPath)
+    #             return @{ Path = Join-Path $TargetPath $Name }
+    #         }
+    #         Mock Get-ExtensionDependencies {
+    #             param ($Extension)
+    #             return @()
+    #         }
+    #         Mock Test-Path {
+    #             param ($Path)
+    #             return $true
+    #         }
+    #         Mock Write-Warning {}
+    #         Mock Write-Host {}
+    #     }
+
+    #     Context 'When Get-ExtensionFromGitRepository throws an error' {
+    #         It 'Should propagate the exception' {
+    #             Mock Get-ExtensionFromGitRepository {
+    #                 throw "Mock Git Repository Error"
+    #             }
+
+    #             $extensionConfig = @{
+    #                 Name = "ErrorGitExtension"
+    #                 GitRepository = "https://github.com/error/git"
+    #             }
+
+    #             { Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath } | Should -Throw "Mock Git Repository Error"
+    #         }
+    #     }
+
+    #     Context 'When Get-ExtensionDependencies throws an error' {
+    #         It 'Should propagate the exception' {
+    #             Mock Get-ExtensionDependencies {
+    #                 throw "Mock Dependency Error"
+    #             }
+
+    #             $extensionConfig = @{
+    #                 Name = "ErrorDepExtension"
+    #                 Path = "$targetPath/error-dep"
+    #             }
+
+    #             { Register-ExtensionAndDependencies -ExtensionConfig $extensionConfig -TargetPath $targetPath } | Should -Throw "Mock Dependency Error"
+    #         }
+    #     }
+    # }
+
+    Context 'Invalid extension path configuration' {
+        BeforeAll {
+            $invalidExtensionPath = "$PWD/does-not-exist"
+        }
+
+        Context 'Simple syntax' {
+            It 'Should throw an exception' {
+                $mockInvalidSimpleExtensionConfig = $invalidExtensionPath
+                {
+                    Register-ExtensionAndDependencies $mockInvalidSimpleExtensionConfig $targetPath
+                } | Should -Throw "Unable to find the extension's module manifest in '$invalidExtensionPath'"
+            }
+        }
+
+        Context 'Hashtable syntax' {
+            It 'Should throw an exception' {
+                $mockInvalidHashtableExtensionConfig = @{
+                    Path = $invalidExtensionPath
+                }
+                {
+                    Register-ExtensionAndDependencies $mockInvalidHashtableExtensionConfig $targetPath
+                } | Should -Throw "Unable to find the extension's module manifest in '$invalidExtensionPath'"
             }
         }
     }

--- a/module/functions/Register-ExtensionAndDependencies.Tests.ps1
+++ b/module/functions/Register-ExtensionAndDependencies.Tests.ps1
@@ -29,10 +29,6 @@ Describe 'Register-ExtensionAndDependencies' {
 
         Mock Write-Host {}
         Mock Write-Warning {}
-        # Mock Get-ExtensionAvailableTasks {
-        #     param ($ExtensionPath)
-        #     return @("MockTask1", "MockTask2")
-        # }
     }
 
     Context 'Git-Based Extensions' {

--- a/module/functions/Register-ExtensionAndDependencies.ps1
+++ b/module/functions/Register-ExtensionAndDependencies.ps1
@@ -69,7 +69,7 @@ function Register-ExtensionAndDependencies {
     elseif (!$extension.ContainsKey("Path")) {
         # PowerShell module-based extension
         # Set defaults for any optional configuration settings
-        $splat.Add("PSRepository", $extension.ContainsKey("PSRepository") ? $extension.PSRepository : $DefaultPSRepository)
+        $splat["PSRepository"] = $extension.ContainsKey("PSRepository") ? $extension.PSRepository : $DefaultPSRepository
         
         # Call the helper that will install the extension from a PowerShell module repository if it's not
         # already installed and provide the resulting additional metadata that we need to use the extension

--- a/module/functions/Register-ExtensionAndDependencies.ps1
+++ b/module/functions/Register-ExtensionAndDependencies.ps1
@@ -48,43 +48,50 @@ function Register-ExtensionAndDependencies {
     $splat = $extension.Clone()
     $splat.Remove("Process") | Out-Null
     $splat.Add("TargetPath", $TargetPath)
-    if ($extension.ContainsKey("GitRepository")) {
-        # Git-based extension
-        $splat.Remove("GitRepository")
-        $splat.Add("RepositoryUri", $extension.GitRepository)
-        # Set defaults for any optional configuration settings
-        if (!$extension.ContainsKey("GitRef")) { $splat.Add("GitRef", 'main') }
-        if ($extension.ContainsKey("GitRepositoryFolderPath")) {
-            $splat.Remove("GitRepositoryFolderPath")
-            $splat.Add("RepositoryFolderPath", $extension.GitRepositoryFolderPath)
+
+    # Skip further processing is extension is explicitly disabled
+    if (!$extension.ContainsKey('Enabled') -or $extension.Enabled) {
+        if ($extension.ContainsKey("GitRepository")) {
+            # Git-based extension
+            $splat.Remove("GitRepository")
+            $splat.Add("RepositoryUri", $extension.GitRepository)
+            # Set defaults for any optional configuration settings
+            if (!$extension.ContainsKey("GitRef")) { $splat.Add("GitRef", 'main') }
+            if ($extension.ContainsKey("GitRepositoryFolderPath")) {
+                $splat.Remove("GitRepositoryFolderPath")
+                $splat.Add("RepositoryFolderPath", $extension.GitRepositoryFolderPath)
+            }
+            else {
+                $splat.Add("RepositoryFolderPath", 'module')
+            }
+    
+            # Call the helper that will install the extension from a Git repository if it's not
+            # already installed and provide the resulting additional metadata that we need to use the extension
+            $extension += Get-ExtensionFromGitRepository @splat
+        }
+        elseif (!$extension.ContainsKey("Path")) {
+            # PowerShell module-based extension
+            # Set defaults for any optional configuration settings
+            $splat["PSRepository"] = $extension.ContainsKey("PSRepository") ? $extension.PSRepository : $DefaultPSRepository
+            
+            # Call the helper that will install the extension from a PowerShell module repository if it's not
+            # already installed and provide the resulting additional metadata that we need to use the extension
+            $extension += Get-ExtensionFromPowerShellRepository @splat
+        }
+        elseif ((Test-Path $extension.Path)) {
+            # Local file-system-based extension
+            $extension['Enabled'] = $extension.ContainsKey('Enabled') ? $extension.Enabled : $true
+            Write-Host "USING PATH: $($extension.Name) ($($extension.Path))" -f Cyan
         }
         else {
-            $splat.Add("RepositoryFolderPath", 'module')
+            # Missing local extension or invalid config
+            Write-Warning "Extension '$($extension.Name)' not found at $($extension.Path) - it has been disabled."
+            $extension['Enabled'] = $false
+            continue
         }
-
-        # Call the helper that will install the extension from a Git repository if it's not
-        # already installed and provide the resulting additional metadata that we need to use the extension
-        $extension += Get-ExtensionFromGitRepository @splat
-    }
-    elseif (!$extension.ContainsKey("Path")) {
-        # PowerShell module-based extension
-        # Set defaults for any optional configuration settings
-        $splat["PSRepository"] = $extension.ContainsKey("PSRepository") ? $extension.PSRepository : $DefaultPSRepository
-        
-        # Call the helper that will install the extension from a PowerShell module repository if it's not
-        # already installed and provide the resulting additional metadata that we need to use the extension
-        $extension += Get-ExtensionFromPowerShellRepository @splat
-    }
-    elseif ((Test-Path $extension.Path)) {
-        # Local file-system-based extension
-        $extension.Add("Enabled", $true)
-        Write-Host "USING PATH: $($extension.Name) ($($extension.Path))" -f Cyan
     }
     else {
-        # Missing local extension or invalid config
-        Write-Warning "Extension '$($extension.Name)' not found at $($extension.Path) - it has been disabled."
-        $extension.Add("Enabled", $false)
-        continue
+        Write-Host "Skipping extension - explicitly disabled"
     }
     
     # If enabled, interrogate the extension for its dependencies and exported tasks? recursive?

--- a/module/functions/Resolve-ExtensionMetadata.Tests.ps1
+++ b/module/functions/Resolve-ExtensionMetadata.Tests.ps1
@@ -97,4 +97,13 @@ Describe 'Resolve-ExtensionMetadata' {
             }
         }
     }
+
+    Context 'Invalid configuration' {
+        It 'Should throw an exception when Name and Path are missing' {
+            $config = @{}
+            {
+                Resolve-ExtensionMetadata $config
+            } | Should -Throw "Invalid extension configuration syntax."
+        }
+    }
 }

--- a/module/functions/Resolve-ExtensionMetadata.ps1
+++ b/module/functions/Resolve-ExtensionMetadata.ps1
@@ -74,14 +74,14 @@ function Resolve-ExtensionMetadata {
         # Assume full object-based syntax
         $extension = $Value
     }
-    else {
-        throw "Invalid extension configuration syntax. Expected a string or hashtable, but found $($Value.GetType().Name)"
-    }
 
     # Ensure we have the module name, as this is needed to ensure our duplicate extension detection works correctly
     # We can be missing this when the extension is specified as a path using either the simple or object syntax.
-    if (!$extension.ContainsKey("Name")) {
+    if (!$extension.ContainsKey("Name") -and $extension.ContainsKey("Path")) {
         $extension.Add("Name", (_resolveModuleNameFromPath $extension.Path))
+    }
+    elseif (!$extension.ContainsKey("Name")) {
+        throw "Invalid extension configuration syntax."
     }
 
     Write-Verbose "Resolved extension metadata: $($extension | ConvertTo-Json)"

--- a/module/functions/_resolveModuleNameFromPath.Tests.ps1
+++ b/module/functions/_resolveModuleNameFromPath.Tests.ps1
@@ -1,0 +1,65 @@
+# <copyright file="_resolveModuleNameFromPath.Tests.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+BeforeAll {
+    # sut
+    . $PSCommandPath.Replace('.Tests.ps1','.ps1')
+}
+
+Describe '_resolveModuleNameFromPath' {
+    Context 'Valid module path' {
+        BeforeAll {
+            $testModulePath = Join-Path TestDrive: "TestModule"
+            New-Item -Path $testModulePath -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path $testModulePath "TestModule.psd1") -ItemType File -Force | Out-Null
+        }
+
+        It 'Should return the correct module name for a single psd1' {
+            $moduleName = _resolveModuleNameFromPath -Path $testModulePath
+            $moduleName | Should -Be "TestModule"
+        }
+    }
+
+    Context 'Valid module path with multiple psd1 files' {
+        BeforeAll {            
+            $testModulePath = Join-Path TestDrive: "MultiPsd1Module"
+            New-Item -Path $testModulePath -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path $testModulePath "ModuleA.psd1") -ItemType File -Force | Out-Null
+            New-Item -Path (Join-Path $testModulePath "ModuleB.psd1") -ItemType File -Force | Out-Null
+        }
+        
+        It 'Should return the first module name found and log a warning' {
+            Mock Write-Warning {}
+
+            $moduleName = _resolveModuleNameFromPath -Path $testModulePath
+            $moduleName | Should -Be "ModuleA"
+            Should -Invoke Write-Warning -Times 1 -Exactly -Scope Context
+        }
+    }
+
+    Context 'Invalid module path - no psd1 files' {
+        BeforeAll {
+            $testModulePath = Join-Path TestDrive: "NoPsd1Module"
+            New-Item -Path $testModulePath -ItemType Directory -Force | Out-Null
+        }
+
+        It 'Should throw an exception' {
+            {
+                _resolveModuleNameFromPath -Path $testModulePath
+            } | Should -Throw "Unable to find the extension's module manifest in '$testModulePath'"
+        }
+    }
+
+    Context 'Invalid module path - non-existent directory' {
+        BeforeAll {
+            $nonExistentPath = Join-Path TestDrive: "NonExistentDir"
+        }
+
+        It 'Should throw an exception' {
+            {
+                _resolveModuleNameFromPath -Path $nonExistentPath
+            } | Should -Throw "Unable to find the extension's module manifest in '$nonExistentPath'"
+        }
+    }
+}

--- a/module/functions/_resolveModuleNameFromPath.ps1
+++ b/module/functions/_resolveModuleNameFromPath.ps1
@@ -31,10 +31,13 @@ function _resolveModuleNameFromPath {
         [string] $Path
     )
 
-    $moduleManifestPaths = Get-ChildItem -Path $Path -Filter "*.psd1" | Where-Object { $_.BaseName -ne "dependencies" }
+    $moduleManifestPaths = Get-ChildItem -Path $Path -Filter "*.psd1" -ErrorAction Ignore | Where-Object { $_.BaseName -ne "dependencies" }
     $moduleManifestPath = $moduleManifestPaths | Select-Object -First 1
-    if ($moduleManifestPath.Count -gt 1) {
+    if ($moduleManifestPaths.Count -gt 1) {
         Write-Warning "Found multiple module manifest files in '$Path' - using the first one found ($moduleManifestPath.BaseName)"
+    }
+    elseif ($moduleManifestPaths.Count -eq 0) {
+        throw "Unable to find the extension's module manifest in '$Path'"
     }
 
     return $moduleManifestPath.BaseName


### PR DESCRIPTION
Changes the mechanism by which ZeroFailed extensions declare other extensions they depend on, based on a decision captured in `adr0001`.

A backwards-compatible change that deprecates the use of `dependencies.psd1` in favour using the `PrivateData` area of the module manifest.

Other updates:
* Improved test coverage
* Updated Pester version and enabled code coverage

Fixes #5 